### PR TITLE
Configured maven-gpg-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <version.maven-site-plugin>4.0.0-M7</version.maven-site-plugin>
         <version.maven-surefire-plugin>3.0.0</version.maven-surefire-plugin>
         <version.spotbugs-maven-plugin>4.7.3.4</version.spotbugs-maven-plugin>
+        <version.maven-gpg-plugin>3.2.7</version.maven-gpg-plugin>
 
         <!-- Version 9.3 is the last version supporting JDK8 so we need to keep it as long as we still need JDK8 support -->
         <version.com-puppycrawl-tools.checkstyle>9.3</version.com-puppycrawl-tools.checkstyle>
@@ -338,6 +339,20 @@
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <tagNameFormat>@{version}</tagNameFormat>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>${version.maven-gpg-plugin}</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
To enable GPG signing of built artifacts we need configured maven-gpg-plugin.

The signing will happen during `verify` phase. To test this yourself, first configure your GPG key and then execute `mvn verify`.