### PR TITLE
Added gpg-sign to releaseProfiles, closes #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,5 +169,5 @@ Distribution is copied as `dist-diff2-$VERSION-jar-with-dependencies.jar` into y
 Please note that the prerequisite is to have read/write permission to the repo configured in `pom.xml` `scm` tag.
 
 1. `mvn release:clean`
-2. `mvn release:prepare -Pgpg-sign` — if the process fails here, revert using `mvn release:rollback`. Note that the `gpg-agent` must be running and your passphrase must be cached after running e.g. `gpg --sign --detach-sign <file>`.
-3. `mvn release:perform`
+2. `mvn release:prepare` — if the process fails here, revert using `mvn release:rollback`.
+3. `mvn release:perform` — note that the `gpg-agent` must be running and your passphrase must be cached after running e.g. `gpg --sign --detach-sign <file>`.

--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>
+                    <releaseProfiles>gpg-sign</releaseProfiles>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <tagNameFormat>@{version}</tagNameFormat>
                 </configuration>


### PR DESCRIPTION
Moved profile to `releaseProfiles` so a user doesn't have to explicitly configure it when making a release.